### PR TITLE
clean bundler environment before boostrapping another

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,7 @@ task :default => :test
 
 mock = ENV['FOG_MOCK'] || 'true'
 task :test do
-  sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+  Bundler.with_clean_env do
+    sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+  end
 end


### PR DESCRIPTION
Bundler's environment passes onto any shell commands that get run. `Bundler.with_clean_env` discards the environment, so `bundle exec` can function properly in the `sh` call.