### PR TITLE
Add Affinity Group support

### DIFF
--- a/lib/fog/cloudstack/models/compute/server.rb
+++ b/lib/fog/cloudstack/models/compute/server.rb
@@ -25,6 +25,8 @@ module Fog
         attribute :password_enabled,                        :aliases => 'passwordenabled'
         attribute :flavor_id,                               :aliases => ['serviceofferingid', :service_offering_id]
         attribute :flavor_name,                             :aliases => ['serviceofferingname', :service_offering_name]
+        attribute :affinity_group_ids,                      :aliases => 'affinitygroupids'
+        attribute :affinity_group_names,                    :aliases => 'affinitygroupnames'
         attribute :cpu_number,                              :aliases => 'cpunumber'
         attribute :cpu_speed,                               :aliases => 'cpuspeed'
         attribute :cpu_used,                                :aliases => 'cpuused'
@@ -133,6 +135,8 @@ module Fog
             'size'              => size,
           }
 
+          options.merge!('affinitygroupids' => affinity_group_ids) if affinity_group_ids
+          options.merge!('affinitygroupnames' => affinity_group_names) if affinity_group_names
           options.merge!('rootdisksize' => root_disk_size) if root_disk_size
           options.merge!('networkids' => network_ids) if network_ids
           options.merge!('securitygroupids' => security_group_ids) unless security_group_ids.empty?

--- a/lib/fog/cloudstack/requests/compute/deploy_virtual_machine.rb
+++ b/lib/fog/cloudstack/requests/compute/deploy_virtual_machine.rb
@@ -51,6 +51,9 @@ module Fog
           service_offering_cpu_speed = service_offering[:cpuspeed]
           service_offering_memory = service_offering[:cpumemory]
 
+          affinity_group_ids = options['affinity_group_ids']
+          affinity_group_names = options['affinity_group_names']
+
           identity = Fog::Cloudstack.uuid
           name = options['name'] || Fog::Cloudstack.uuid
           display_name = options['displayname'] || name
@@ -89,6 +92,8 @@ module Fog
             "name" => name,
             "displayname" => display_name,
             "account" => account_name,
+            "affinitygroupids" => affinity_group_ids,
+            "affinitygroupnames" => affinity_group_names,
             "domainid" => domain_id,
             "domain" => domain_name,
             "created" => Time.now.to_s,


### PR DESCRIPTION
This PR adds the ability to specify either Affinity Group IDs or Names when deploying an instance using this gem.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>