### PR TITLE
Upgrade rubyzip dependency

### DIFF
--- a/fog-cloudstack.gemspec
+++ b/fog-cloudstack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake',    '~> 10.0'
-  spec.add_development_dependency 'rubyzip', '~> 1.2.1'
+  spec.add_development_dependency 'rubyzip', '~> 1.3.0'
   spec.add_development_dependency 'shindo',  '~> 0.3'
 
   spec.add_dependency 'fog-core',  '~> 2.1'


### PR DESCRIPTION
I got an email from Github about a vulnerability in prior versions of
rubyzip and decided that I should probably fix it. Being a little bit
out of touch with the Ruby ecosystem and what changes has been
introduced in newer versions of rubyzip, I am not sure if everything is
correct. I have run the tests on Ruby 2.6.5 (see specifics in the end of
the message) by running `rake test`.

The change made is to update rubyzip required version to 1.3.0, this
seems to be the latest version to use without requiring Ruby 2.x. I am
not sure if we need to do this, otherwise we can upgrade to rubyzip
2.0.0 which is the latest version.

Tested on the following version of Ruby:

`ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]`